### PR TITLE
Reinstate SignedJwtAssertionCredentials API for compatibility with old code

### DIFF
--- a/oauth2client/client.py
+++ b/oauth2client/client.py
@@ -2161,3 +2161,13 @@ def flow_from_clientsecrets(filename, scope, redirect_uri=None,
     else:
         raise UnknownClientSecretsFlowError(
             'This OAuth 2.0 flow is unsupported: {0!r}'.format(client_type))
+
+
+def SignedJwtAssertionCredentials(*args, **kwargs):
+    """
+    Deprecated legacy API. New code should use ServiceAccountCredentials
+    instead.
+    """
+    # Import inside of function to prevent circular module dependency
+    from oauth2client import service_account  # NOQA
+    return service_account.SignedJwtAssertionCredentials(*args, **kwargs)


### PR DESCRIPTION
Please consider this pull request to re-add the old method signature for creation of `SignedJwtAssertionCredentials`.

There is a lot of old code out there that uses it - and since the new class is essentially equivalent to the old, it would save a lot of work for a lot of people to have the core library handle the name change for them.